### PR TITLE
chore: type game operation results

### DIFF
--- a/src/routes/dashboard/games/create.tsx
+++ b/src/routes/dashboard/games/create.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from "~/components/ui/select";
 import { getCampaign } from "~/features/campaigns/campaigns.queries";
+import type { CampaignWithDetails } from "~/features/campaigns/campaigns.types";
 import { GameForm } from "~/features/games/components/GameForm";
 import {
   createGame,
@@ -29,6 +30,8 @@ import {
   gameFormSchema,
   updateGameInputSchema,
 } from "~/features/games/games.schemas";
+import type { GameWithDetails } from "~/features/games/games.types";
+import type { OperationResult } from "~/shared/types/common";
 
 const createGameSearchSchema = z.object({
   campaignId: z.string().optional(),
@@ -49,7 +52,7 @@ export function CreateGamePage() {
     data: campaignData,
     isPending: isCampaignDataPending,
     isSuccess: isCampaignDataSuccess,
-  } = useQuery({
+  } = useQuery<OperationResult<CampaignWithDetails | null>>({
     queryKey: ["campaign", campaignId],
     queryFn: () => getCampaign({ data: { id: campaignId! } }),
     enabled: !!campaignId,
@@ -114,9 +117,12 @@ export function CreateGamePage() {
     return {};
   }, [isCampaignDataSuccess, campaignData, campaignId]);
 
-  const createGameMutation = useMutation({
-    mutationFn: async (args: { data: z.infer<typeof createGameInputSchema> }) => {
-      // If creating within a campaign, leverage the campaign-aware server fn
+  const createGameMutation = useMutation<
+    OperationResult<GameWithDetails>,
+    Error,
+    { data: z.infer<typeof createGameInputSchema> }
+  >({
+    mutationFn: async (args) => {
       if (campaignId) {
         return await createGameSessionForCampaign({
           data: args.data as z.infer<typeof createGameInputSchema>,

--- a/src/routes/dashboard/games/index.tsx
+++ b/src/routes/dashboard/games/index.tsx
@@ -29,7 +29,10 @@ export const Route = createFileRoute("/dashboard/games/")({
     pageSize: z.coerce.number().int().min(1).max(100).optional(),
   }),
   loader: async () => {
-    const result = await listGamesWithCount({
+    const result: OperationResult<{
+      items: GameListItem[];
+      totalCount: number;
+    }> = await listGamesWithCount({
       data: { filters: { status: "scheduled" }, page: 1, pageSize: 20 },
     });
     if (!result.success) {
@@ -52,10 +55,15 @@ export function GamesPage() {
   const queryClient = useQueryClient();
 
   const pageSize = Math.min(100, Math.max(1, Number(searchPageSize ?? 20)));
-  const { data: gamesData } = useSuspenseQuery({
+  const { data: gamesData } = useSuspenseQuery<
+    OperationResult<{ items: GameListItem[]; totalCount: number }>
+  >({
     queryKey: ["allVisibleGames", status, page, pageSize],
     queryFn: async () => {
-      const result = await listGamesWithCount({
+      const result: OperationResult<{
+        items: GameListItem[];
+        totalCount: number;
+      }> = await listGamesWithCount({
         data: { filters: { status }, page, pageSize },
       });
       if (!result.success) {


### PR DESCRIPTION
## Summary
- ensure game queries return OperationResult and add error handling for getGameSystem
- type route loaders and mutations with OperationResult so success/data/errors are recognized

## Testing
- `pnpm lint`
- `pnpm check-types`


------
https://chatgpt.com/codex/tasks/task_e_68c70b3517bc832a88af7cecfa548d99